### PR TITLE
Add COLLECTION_TYPE as supported constant when generating relation block

### DIFF
--- a/src/PhpFileRenderer/Item/RelationBlock.php
+++ b/src/PhpFileRenderer/Item/RelationBlock.php
@@ -14,6 +14,7 @@ class RelationBlock extends ArrayBlock
      * @see SchemaInterface
      */
     private const RELATION_SCHEMA_KEYS = [
+        'COLLECTION_TYPE',
         'MORPH_KEY',
         'CASCADE',
         'NULLABLE',


### PR DESCRIPTION
## 🔍 What was changed

* Added `COLLECTION_TYPE` as supported constant when generating relation block.

## 🤔 Why?

Because those with OCD will care.

## 📝 Checklist

- Closes #19